### PR TITLE
Cross platform named semaphore

### DIFF
--- a/src/Gemstone.Threading/Gemstone.Threading.csproj
+++ b/src/Gemstone.Threading/Gemstone.Threading.csproj
@@ -36,6 +36,7 @@
 
   <PropertyGroup>
     <DocumentationFile>..\..\build\$(Configuration)\$(AssemblyName).xml</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Development'">

--- a/src/Gemstone.Threading/INamedSemaphore.cs
+++ b/src/Gemstone.Threading/INamedSemaphore.cs
@@ -20,9 +20,9 @@
 //       Generated original version of source code.
 //
 //******************************************************************************************************
+// ReSharper disable UnusedMember.Global
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Win32.SafeHandles;
 
 namespace Gemstone.Threading
@@ -38,8 +38,7 @@ namespace Gemstone.Threading
 
     internal interface INamedSemaphore : IDisposable
     {
-        [AllowNull]
-        SafeWaitHandle SafeWaitHandle { get; set; }
+        SafeWaitHandle? SafeWaitHandle { get; set; }
 
         void CreateSemaphoreCore(int initialCount, int maximumCount, string name, out bool createdNew);
 
@@ -58,5 +57,7 @@ namespace Gemstone.Threading
         bool WaitOne(int millisecondsTimeout, bool exitContext);
 
         static OpenExistingResult OpenExistingWorker(string name, out INamedSemaphore? semaphore) => throw new NotImplementedException();
+
+        static void Unlink(string name) => throw new NotImplementedException();
     }
 }

--- a/src/Gemstone.Threading/INamedSemaphore.cs
+++ b/src/Gemstone.Threading/INamedSemaphore.cs
@@ -1,0 +1,62 @@
+﻿//******************************************************************************************************
+//  INamedSemaphore.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  11/09/2023 - Ritchie Carroll
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Win32.SafeHandles;
+
+namespace Gemstone.Threading
+{
+    internal enum OpenExistingResult
+    {
+        Success,
+        NameNotFound,
+        NameInvalid,
+        PathTooLong,
+        AccessDenied
+    }
+
+    internal interface INamedSemaphore : IDisposable
+    {
+        [AllowNull]
+        SafeWaitHandle SafeWaitHandle { get; set; }
+
+        void CreateSemaphoreCore(int initialCount, int maximumCount, string name, out bool createdNew);
+
+        int ReleaseCore(int releaseCount);
+
+        void Close();
+
+        bool WaitOne();
+
+        bool WaitOne(TimeSpan timeout);
+
+        bool WaitOne(int millisecondsTimeout);
+
+        bool WaitOne(TimeSpan timeout, bool exitContext);
+
+        bool WaitOne(int millisecondsTimeout, bool exitContext);
+
+        static OpenExistingResult OpenExistingWorker(string name, out INamedSemaphore? semaphore) => throw new NotImplementedException();
+    }
+}

--- a/src/Gemstone.Threading/InterprocessLock.cs
+++ b/src/Gemstone.Threading/InterprocessLock.cs
@@ -31,13 +31,13 @@
 //       Improved operational behavior.
 //
 //******************************************************************************************************
+#pragma warning disable VSSpell001
 
 using System;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Threading;
 using Gemstone.Identity;
@@ -77,7 +77,7 @@ public static class InterprocessLock
         string? name = attribute?.Value ?? entryAssembly.GetName().Name;
 
         if (perUser)
-            name += UserInfo.CurrentUserID ?? string.Empty;
+            name += UserInfo.CurrentUserID;
 
         return GetNamedMutex(name!, !perUser);
     }
@@ -109,7 +109,7 @@ public static class InterprocessLock
             throw new ArgumentNullException(nameof(name), "Argument cannot be empty, null or white space.");
 
         // Create a mutex name that is specific to an object (e.g., a path and file name).
-        // Note that we use GetStringHash to create a short common name for the name parameter
+        // Note that we use a SHA hash to create a short common name for the name parameter
         // that was passed into the function - this allows the parameter to be very long, e.g.,
         // a file path, and still meet minimum mutex name requirements.
 
@@ -125,65 +125,75 @@ public static class InterprocessLock
     }
 
     /// <summary>
-    /// Gets a uniquely named inter-process <see cref="Semaphore"/> associated with the running application, typically used to detect whether some number of
+    /// Gets a uniquely named inter-process <see cref="NamedSemaphore"/> associated with the running application, typically used to detect whether some number of
     /// instances of the application are already running.
     /// </summary>
-    /// <param name="perUser">Indicates whether to generate a different name for the <see cref="Semaphore"/> dependent upon the user running the application.</param>
+    /// <param name="perUser">Indicates whether to generate a different name for the <see cref="NamedSemaphore"/> dependent upon the user running the application.</param>
     /// <param name="maximumCount">The maximum number of requests for the semaphore that can be granted concurrently.</param>
     /// <param name="initialCount">The initial number of requests for the semaphore that can be granted concurrently, or -1 to default to <paramref name="maximumCount"/>.</param>
-    /// <returns>A uniquely named inter-process <see cref="Semaphore"/> specific to entry assembly; <see cref="Semaphore"/> is created if it does not exist.</returns>
+    /// <returns>A uniquely named inter-process <see cref="NamedSemaphore"/> specific to entry assembly; <see cref="NamedSemaphore"/> is created if it does not exist.</returns>
     /// <remarks>
     /// <para>
-    /// This function uses a hash of the assembly's GUID when creating the <see cref="Semaphore"/>, if it is available. If it is not available, it uses a hash
+    /// This function uses a hash of the assembly's GUID when creating the <see cref="NamedSemaphore"/>, if it is available. If it is not available, it uses a hash
     /// of the simple name of the assembly. Although the name is hashed to help guarantee uniqueness, it is still entirely possible that another application
-    /// may use that name with the same hashing algorithm to generate its <see cref="Semaphore"/> name. Therefore, it is best to ensure that the
+    /// may use that name with the same hashing algorithm to generate its <see cref="NamedSemaphore"/> name. Therefore, it is best to ensure that the
     /// <see cref="GuidAttribute"/> is defined in the AssemblyInfo of your application.
+    /// </para>
+    /// <para>
+    /// On POSIX systems, the <see cref="NamedSemaphore"/> exhibits kernel persistence, meaning instances will remain active beyond the lifespan of the
+    /// creating process. Named semaphores must be explicitly removed by invoking <see cref="NamedSemaphore.Unlink"/> when they are no longer needed.
+    /// Kernel persistence necessitates careful design consideration regarding the responsibility for invoking <see cref="NamedSemaphore.Unlink"/>.
+    /// Since the common use case for named semaphores is across multiple applications, it is advisable for the last exiting process to handle the
+    /// cleanup. In cases where an application may crash before calling <see cref="NamedSemaphore.Unlink"/>, the semaphore persists in the system,
+    /// potentially leading to resource leakage. Implementations should include strategies to address and mitigate this risk.
     /// </para>
     /// </remarks>
     /// <exception cref="UnauthorizedAccessException">The named semaphore exists, but the user does not have the minimum needed security access rights to use it.</exception>
     [MethodImpl(MethodImplOptions.Synchronized)]
-#if NET
-    [SupportedOSPlatform("Windows")]
-#endif
-    public static Semaphore GetNamedSemaphore(bool perUser, int maximumCount = 10, int initialCount = -1)
+    public static NamedSemaphore GetNamedSemaphore(bool perUser, int maximumCount = 10, int initialCount = -1)
     {
         Assembly entryAssembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
         GuidAttribute? attribute = entryAssembly.GetCustomAttributes(typeof(GuidAttribute), true).FirstOrDefault() as GuidAttribute;
         string? name = attribute?.Value ?? entryAssembly.GetName().Name;
 
         if (perUser)
-            name += UserInfo.CurrentUserID ?? string.Empty;
+            name += UserInfo.CurrentUserID;
 
         return GetNamedSemaphore(name!, maximumCount, initialCount, !perUser);
     }
 
     /// <summary>
-    /// Gets a uniquely named inter-process <see cref="Semaphore"/> associated with the specified <paramref name="name"/> that identifies a source object
+    /// Gets a uniquely named inter-process <see cref="NamedSemaphore"/> associated with the specified <paramref name="name"/> that identifies a source object
     /// needing concurrency locking.
     /// </summary>
     /// <param name="name">Identifying name of source object needing concurrency locking (e.g., a path and file name).</param>
     /// <param name="maximumCount">The maximum number of requests for the semaphore that can be granted concurrently.</param>
     /// <param name="initialCount">The initial number of requests for the semaphore that can be granted concurrently, or -1 to default to <paramref name="maximumCount"/>.</param>
     /// <param name="global">Determines if semaphore should be marked as global; set value to <c>false</c> for local.</param>
-    /// <returns>A uniquely named inter-process <see cref="Semaphore"/> specific to <paramref name="name"/>; <see cref="Semaphore"/> is created if it does not exist.</returns>
+    /// <returns>A uniquely named inter-process <see cref="NamedSemaphore"/> specific to <paramref name="name"/>; <see cref="NamedSemaphore"/> is created if it does not exist.</returns>
     /// <remarks>
     /// <para>
-    /// This function uses a hash of the <paramref name="name"/> when creating the <see cref="Semaphore"/>, not the actual <paramref name="name"/> - this way
-    /// restrictions on the <paramref name="name"/> length do not need to be a user concern. All processes needing an inter-process <see cref="Semaphore"/> need
-    /// to use this same function to ensure access to the same <see cref="Semaphore"/>.
+    /// This function uses a hash of the <paramref name="name"/> when creating the <see cref="NamedSemaphore"/>, not the actual <paramref name="name"/> - this way
+    /// restrictions on the <paramref name="name"/> length do not need to be a user concern. All processes needing an inter-process <see cref="NamedSemaphore"/> need
+    /// to use this same function to ensure access to the same <see cref="NamedSemaphore"/>.
     /// </para>
     /// <para>
     /// The <paramref name="name"/> can be a string of any length (must not be empty, null or white space) and is not case-sensitive. All hashes of the
-    /// <paramref name="name"/> used to create the global <see cref="Semaphore"/> are first converted to lower case.
+    /// <paramref name="name"/> used to create the global <see cref="NamedSemaphore"/> are first converted to lower case.
+    /// </para>
+    /// <para>
+    /// On POSIX systems, the <see cref="NamedSemaphore"/> exhibits kernel persistence, meaning instances will remain active beyond the lifespan of the
+    /// creating process. Named semaphores must be explicitly removed by invoking <see cref="NamedSemaphore.Unlink"/> when they are no longer needed.
+    /// Kernel persistence necessitates careful design consideration regarding the responsibility for invoking <see cref="NamedSemaphore.Unlink"/>.
+    /// Since the common use case for named semaphores is across multiple applications, it is advisable for the last exiting process to handle the
+    /// cleanup. In cases where an application may crash before calling <see cref="NamedSemaphore.Unlink"/>, the semaphore persists in the system,
+    /// potentially leading to resource leakage. Implementations should include strategies to address and mitigate this risk.
     /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException">Argument <paramref name="name"/> cannot be empty, null or white space.</exception>
     /// <exception cref="UnauthorizedAccessException">The named semaphore exists, but the user does not have the minimum needed security access rights to use it.</exception>
     [MethodImpl(MethodImplOptions.Synchronized)]
-#if NET
-    [SupportedOSPlatform("Windows")]
-#endif
-    public static Semaphore GetNamedSemaphore(string name, int maximumCount = 10, int initialCount = -1, bool global = true)
+    public static NamedSemaphore GetNamedSemaphore(string name, int maximumCount = 10, int initialCount = -1, bool global = true)
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentNullException(nameof(name), "Argument cannot be empty, null or white space.");
@@ -192,7 +202,7 @@ public static class InterprocessLock
             initialCount = maximumCount;
 
         // Create a semaphore name that is specific to an object (e.g., a path and file name).
-        // Note that we use GetPasswordHash to create a short common name for the name parameter
+        // Note that we use a SHA hash to create a short common name for the name parameter
         // that was passed into the function - this allows the parameter to be very long, e.g.,
         // a file path, and still meet minimum semaphore name requirements.
 
@@ -201,8 +211,8 @@ public static class InterprocessLock
         SHA256 hash = new Cipher().CreateSHA256();
         string semaphoreName = $"{(global ? "Global" : "Local")}\\{hash.GetStringHash($"{name.ToLowerInvariant()}{SemaphoreHash}").Replace('\\', '-')}";
 
-        if (!Semaphore.TryOpenExisting(semaphoreName, out Semaphore? namedSemaphore))
-            namedSemaphore = new Semaphore(initialCount, maximumCount, semaphoreName);
+        if (!NamedSemaphore.TryOpenExisting(semaphoreName, out NamedSemaphore? namedSemaphore))
+            namedSemaphore = new NamedSemaphore(initialCount, maximumCount, semaphoreName);
 
         return namedSemaphore;
     }

--- a/src/Gemstone.Threading/InterprocessLock.cs
+++ b/src/Gemstone.Threading/InterprocessLock.cs
@@ -143,7 +143,7 @@ public static class InterprocessLock
     /// <exception cref="UnauthorizedAccessException">The named semaphore exists, but the user does not have the minimum needed security access rights to use it.</exception>
     [MethodImpl(MethodImplOptions.Synchronized)]
 #if NET
-        [SupportedOSPlatform("Windows")]
+    [SupportedOSPlatform("Windows")]
 #endif
     public static Semaphore GetNamedSemaphore(bool perUser, int maximumCount = 10, int initialCount = -1)
     {
@@ -181,7 +181,7 @@ public static class InterprocessLock
     /// <exception cref="UnauthorizedAccessException">The named semaphore exists, but the user does not have the minimum needed security access rights to use it.</exception>
     [MethodImpl(MethodImplOptions.Synchronized)]
 #if NET
-        [SupportedOSPlatform("Windows")]
+    [SupportedOSPlatform("Windows")]
 #endif
     public static Semaphore GetNamedSemaphore(string name, int maximumCount = 10, int initialCount = -1, bool global = true)
     {

--- a/src/Gemstone.Threading/InterprocessReaderWriterLock.cs
+++ b/src/Gemstone.Threading/InterprocessReaderWriterLock.cs
@@ -24,13 +24,13 @@
 //******************************************************************************************************
 
 using System;
-using System.Runtime.Versioning;
 using System.Threading;
 
 namespace Gemstone.Threading;
 
 /// <summary>
-/// Represents an inter-process reader/writer lock using <see cref="Semaphore"/> and <see cref="Mutex"/> native locking mechanisms.
+/// Represents an inter-process reader/writer lock using <see cref="NamedSemaphore"/> and <see cref="Mutex"/>
+/// native locking mechanisms.
 /// </summary>
 public class InterprocessReaderWriterLock : IDisposable
 {
@@ -44,8 +44,8 @@ public class InterprocessReaderWriterLock : IDisposable
     public const int DefaultMaximumConcurrentLocks = 10;
 
     // Fields
-    private readonly Mutex m_semaphoreLock;         // Mutex used to synchronize access to Semaphore
-    private readonly Semaphore m_concurrencyLock;   // Semaphore used for reader/writer lock on consumer object
+    private readonly Mutex m_semaphoreLock;             // Mutex used to synchronize access to Semaphore
+    private readonly NamedSemaphore m_concurrencyLock;  // Semaphore used for reader/writer lock on consumer object
     private bool m_disposed;
 
     #endregion
@@ -119,8 +119,8 @@ public class InterprocessReaderWriterLock : IDisposable
             if (!disposing)
                 return;
 
-            m_concurrencyLock?.Close();
-            m_semaphoreLock?.Close();
+            m_concurrencyLock.Close();
+            m_semaphoreLock.Close();
         }
         finally
         {

--- a/src/Gemstone.Threading/InterprocessReaderWriterLock.cs
+++ b/src/Gemstone.Threading/InterprocessReaderWriterLock.cs
@@ -32,9 +32,6 @@ namespace Gemstone.Threading;
 /// <summary>
 /// Represents an inter-process reader/writer lock using <see cref="Semaphore"/> and <see cref="Mutex"/> native locking mechanisms.
 /// </summary>
-#if NET
-[SupportedOSPlatform("Windows")]
-#endif
 public class InterprocessReaderWriterLock : IDisposable
 {
     #region [ Members ]

--- a/src/Gemstone.Threading/NamedSemaphore.cs
+++ b/src/Gemstone.Threading/NamedSemaphore.cs
@@ -1,0 +1,288 @@
+﻿//******************************************************************************************************
+//  NamedSemaphore.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  11/09/2023 - J. Ritchie Carroll
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+// ReSharper disable InconsistentNaming
+// ReSharper disable OutParameterValueIsAlwaysDiscarded.Local
+#pragma warning disable CA1416
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using Microsoft.Win32.SafeHandles;
+
+namespace Gemstone.Threading;
+
+/// <summary>
+/// Represents a cross-platform interprocess named semaphore that limits the number
+/// of threads that can access a resource or pool of resources concurrently.
+/// </summary>
+public class NamedSemaphore : WaitHandle
+{
+    private readonly INamedSemaphore m_semaphore;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NamedSemaphore" /> class, specifying the initial number of entries,
+    /// the maximum number of concurrent entries, and the name of a system semaphore object.
+    /// </summary>
+    /// <param name="initialCount">The initial number of requests for the semaphore that can be granted concurrently.</param>
+    /// <param name="maximumCount">The maximum number of requests for the semaphore that can be granted concurrently.</param>
+    /// <param name="name">
+    /// The name used to identity the synchronization object resource shared with other processes.
+    /// The name is case-sensitive. The backslash character (\\) is reserved and may only be used to specify a namespace.
+    /// On Unix-based operating systems, the name after excluding the namespace must be a valid file name which contains
+    /// no slashes beyond optional namespace backslash and is limited to 250 characters. 
+    /// </param>
+    public NamedSemaphore(int initialCount, int maximumCount, string name) :
+        this(initialCount, maximumCount, name, out _)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NamedSemaphore" /> class, specifying the initial number of entries,
+    /// the maximum number of concurrent entries, the name of a system semaphore object, and specifying a variable that
+    /// receives a value indicating whether a new system semaphore was created.
+    /// </summary>
+    /// <param name="initialCount">The initial number of requests for the semaphore that can be granted concurrently.</param>
+    /// <param name="maximumCount">The maximum number of requests for the semaphore that can be granted concurrently.</param>
+    /// <param name="name">
+    /// The name used to identity the synchronization object resource shared with other processes.
+    /// The name is case-sensitive. The backslash character (\\) is reserved and may only be used to specify a namespace.
+    /// On Unix-based operating systems, the name after excluding the namespace must be a valid file name which contains
+    /// no slashes beyond optional namespace backslash and is limited to 250 characters. 
+    /// </param>
+    /// <param name="createdNew">
+    /// When method returns, contains <c>true</c> if the specified named system semaphore was created; otherwise,
+    /// <c>false</c> if the semaphore already existed.
+    /// </param>
+    public NamedSemaphore(int initialCount, int maximumCount, string name, out bool createdNew)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentNullException(nameof(name), "Name cannot be null, empty or whitespace.");
+
+        m_semaphore = Common.IsPosixEnvironment ?
+            new NamedSemaphoreUnix() :
+            new NamedSemaphoreWindows();
+
+        m_semaphore.CreateSemaphoreCore(initialCount, maximumCount, name, out createdNew);
+    }
+
+    private NamedSemaphore(INamedSemaphore semaphore)
+    {
+        m_semaphore = semaphore;
+    }
+
+    /// <summary>
+    /// Gets or sets the native operating system handle.
+    /// </summary>
+    public new SafeWaitHandle SafeWaitHandle
+    {
+        get => m_semaphore.SafeWaitHandle;
+        set => base.SafeWaitHandle = m_semaphore.SafeWaitHandle = value;
+    }
+
+    /// <summary>
+    /// When overridden in a derived class, releases the unmanaged resources used by the <see cref="NamedSemaphore" />,
+    /// and optionally releases the managed resources.
+    /// </summary>
+    /// <param name="explicitDisposing">
+    /// <c>true</c> to release both managed and unmanaged resources; otherwise, <c>false</c> to release only
+    /// unmanaged resources.
+    /// </param>
+    protected override void Dispose(bool explicitDisposing)
+    {
+        try
+        {
+            base.Dispose(explicitDisposing);
+        }
+        finally
+        {
+            m_semaphore.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Releases all resources held by the current <see cref="NamedSemaphore" />.
+    /// </summary>
+    public override void Close()
+    {
+        m_semaphore.Close();
+    }
+
+    /// <summary>
+    /// Blocks the current thread until the current <see cref="NamedSemaphore" /> receives a signal.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if the current instance receives a signal. If the current instance is never signaled,
+    /// <see cref="NamedSemaphore" /> never returns.
+    /// </returns>
+    public override bool WaitOne()
+    {
+        return m_semaphore.WaitOne();
+    }
+
+    /// <summary>
+    /// Blocks the current thread until the current instance receives a signal, using a <see cref="TimeSpan" />
+    /// to specify the time interval.
+    /// </summary>
+    /// <param name="timeout">
+    /// A <see cref="TimeSpan" /> that represents the number of milliseconds to wait, or a <see cref="TimeSpan" />
+    /// that represents -1 milliseconds to wait indefinitely.
+    /// </param>
+    /// <returns><c>true</c> if the current instance receives a signal; otherwise, <c>false</c>.</returns>
+    public override bool WaitOne(TimeSpan timeout)
+    {
+        return m_semaphore.WaitOne(timeout);
+    }
+
+    /// <summary>
+    /// Blocks the current thread until the current instance receives a signal, using a 32-bit signed integer to
+    /// specify the time interval in milliseconds.
+    /// </summary>
+    /// <param name="millisecondsTimeout">
+    /// The number of milliseconds to wait, or <see cref="Timeout.Infinite" /> (-1) to wait indefinitely.
+    /// </param>
+    /// <returns><c>true</c> if the current instance receives a signal; otherwise, <c>false</c>.</returns>
+    public override bool WaitOne(int millisecondsTimeout)
+    {
+        return m_semaphore.WaitOne(millisecondsTimeout);
+    }
+
+    /// <summary>
+    /// Blocks the current thread until the current instance receives a signal, using a <see cref="TimeSpan" />
+    /// to specify the time interval and specifying whether to exit the synchronization domain before the wait.
+    /// </summary>
+    /// <param name="timeout">
+    /// A <see cref="TimeSpan" /> that represents the number of milliseconds to wait, or a <see cref="TimeSpan" />
+    /// that represents -1 milliseconds to wait indefinitely.
+    /// </param>
+    /// <param name="exitContext">
+    /// <c>true</c> to exit the synchronization domain for the context before the wait (if in a synchronized context),
+    /// and reacquire it afterward; otherwise, <c>false</c>.
+    /// </param>
+    /// <returns><c>true</c> if the current instance receives a signal; otherwise, <c>false</c>.</returns>
+    public override bool WaitOne(TimeSpan timeout, bool exitContext)
+    {
+        return m_semaphore.WaitOne(timeout, exitContext);
+    }
+
+    /// <summary>
+    /// Blocks the current thread until the current <see cref="NamedSemaphore" /> receives a signal, using a
+    /// 32-bit signed integer to specify the time interval and specifying whether to exit the synchronization
+    /// domain before the wait.
+    /// </summary>
+    /// <param name="millisecondsTimeout">
+    /// The number of milliseconds to wait, or <see cref="Timeout.Infinite" /> (-1) to wait indefinitely.
+    /// </param>
+    /// <param name="exitContext">
+    /// <c>true</c> to exit the synchronization domain for the context before the wait (if in a synchronized context),
+    /// and reacquire it afterward; otherwise, <c>false</c>.
+    /// </param>
+    /// <returns><c>true</c> if the current instance receives a signal; otherwise, <c>false</c>.</returns>
+    public override bool WaitOne(int millisecondsTimeout, bool exitContext)
+    {
+        return m_semaphore.WaitOne(millisecondsTimeout, exitContext);
+    }
+
+    /// <summary>
+    /// Exits the semaphore and returns the previous count.
+    /// </summary>
+    /// <returns>The count on the semaphore before the method was called.</returns>
+    private int Release()
+    {
+        return m_semaphore.ReleaseCore(1);
+    }
+
+    /// <summary>
+    /// Exits the semaphore a specified number of times and returns the previous count.
+    /// </summary>
+    /// <param name="releaseCount">The number of times to exit the semaphore.</param>
+    /// <returns>The count on the semaphore before the method was called.</returns>
+    public int Release(int releaseCount)
+    {
+        if (releaseCount < 1)
+            throw new ArgumentOutOfRangeException(nameof(releaseCount), "Non-negative number required.");
+
+        return m_semaphore.ReleaseCore(releaseCount);
+    }
+
+    private static OpenExistingResult OpenExistingWorker(string name, out INamedSemaphore? semaphore)
+    {
+        return Common.IsPosixEnvironment ? 
+            NamedSemaphoreUnix.OpenExistingWorker(name, out semaphore) : 
+            NamedSemaphoreWindows.OpenExistingWorker(name, out semaphore);
+    }
+
+    /// <summary>
+    /// Opens the specified named semaphore, if it already exists.
+    /// </summary>
+    /// <param name="name">
+    /// The name used to identity the synchronization object resource shared with other processes.
+    /// The name is case-sensitive. The backslash character (\\) is reserved and may only be used to specify a namespace.
+    /// On Unix-based operating systems, the name after excluding the namespace must be a valid file name which contains
+    /// no slashes beyond optional namespace backslash and is limited to 250 characters. 
+    /// </param>
+    /// <returns>An object that represents the named system semaphore.</returns>
+    public static NamedSemaphore OpenExisting(string name)
+    {
+        switch (OpenExistingWorker(name, out INamedSemaphore? result))
+        {
+            case OpenExistingResult.NameNotFound:
+                throw new WaitHandleCannotBeOpenedException();
+            case OpenExistingResult.NameInvalid:
+                throw new WaitHandleCannotBeOpenedException($"Semaphore with name '{name}' cannot be created.");
+            case OpenExistingResult.PathTooLong:
+                throw new IOException($"Path too long for semaphore with name '{name}'.");
+            case OpenExistingResult.AccessDenied:
+                throw new UnauthorizedAccessException($"Access to the semaphore with name '{name}' is denied.");
+            default:
+                Debug.Assert(result is not null, "result should be non-null on success");
+                return new NamedSemaphore(result);
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="name">
+    /// The name used to identity the synchronization object resource shared with other processes.
+    /// The name is case-sensitive. The backslash character (\\) is reserved and may only be used to specify a namespace.
+    /// On Unix-based operating systems, the name after excluding the namespace must be a valid file name which contains
+    /// no slashes beyond optional namespace backslash and is limited to 250 characters. 
+    /// </param>
+    /// <param name="semaphore"></param>
+    /// <returns></returns>
+    public static bool TryOpenExisting(string name, [NotNullWhen(true)] out NamedSemaphore? semaphore)
+    {
+        if (OpenExistingWorker(name, out INamedSemaphore? result) == OpenExistingResult.Success)
+        {
+            semaphore = new NamedSemaphore(result!);
+            return true;
+        }
+
+        semaphore = null;
+        return false;
+    }
+
+    internal new static readonly IntPtr InvalidHandle = WaitHandle.InvalidHandle;
+}

--- a/src/Gemstone.Threading/NamedSemaphoreUnix.cs
+++ b/src/Gemstone.Threading/NamedSemaphoreUnix.cs
@@ -1,0 +1,344 @@
+﻿//******************************************************************************************************
+//  NamedSemaphoreUnix.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  11/09/2023 - Ritchie Carroll
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.Win32.SafeHandles;
+
+namespace Gemstone.Threading;
+
+/*
+   TODO: Implement strategy for cleaning up named semaphores that are no longer in use.
+
+   Since POSIX named semaphores have kernel persistence and must be removed by removed by "sem_unlink" when no longer needed.
+
+   > Note the following challenges:
+
+   1) Kernel Persistence: POSIX named semaphores are persisted in the kernel, meaning they outlive the process that created them. This is
+      useful for inter-process communication, but tricky to manage.
+   
+   2) sem_unlink Responsibility: Deciding which application or part of the application should call sem_unlink is indeed a critical design
+      decision. If the semaphore is intended for use by multiple applications, you typically want the last process to exit to perform the
+      cleanup. However, identifying the "last" process can be complex, especially in dynamic environments.
+   
+   3) Resource Leaks Due to Crashes: If an application crashes before it can call sem_unlink, the semaphore remains in the system, leading
+      to potential resource leaks. This is a risk in any system where cleanup is the responsibility of the process.
+
+   > Thoughts on how to handle these challenges
+
+   Use reference counting for named semaphore instances and track last access time with an app ID using a persisted file:
+
+   Reference Counting and App ID: Each time a process accesses a semaphore, it increments the count in a shared file and records its app ID.
+   When it's done, it decrements the count. This helps track how many processes are currently using the semaphore.
+   
+   Last Access Time: Recording the last access time of the semaphore can be useful for determining if the semaphore has been abandoned.
+   For example, if the last access time is significantly old, and the reference count is not zero (which might indicate an abnormal termination
+   of a process), a cleanup routine can be triggered.
+   
+   Cleanup Strategy: You could implement a cleanup strategy that kicks in based on certain conditions – for instance, if the semaphore hasn't
+   been accessed for a predefined timeout period, or if the application that last incremented the reference count has terminated unexpectedly.
+   
+   Robustness and Error Handling: It's important to ensure that the file operations are robust and handle concurrency well. File locking
+   mechanisms might be necessary to prevent race conditions when multiple processes are reading and writing to the file.
+   
+   Fallback and Recovery: Implement a recovery mechanism in case the file tracking system fails or becomes corrupt. This could be a separate
+   monitoring process or part of the application startup routine.
+ */
+
+internal partial class NamedSemaphoreUnix : INamedSemaphore
+{
+    // DllImport code is in Gemstone.POSIX.c
+    private const string ImportFileName = "./Gemstone.POSIX.so";
+
+    private readonly ref struct ErrorNo
+    {
+        public const int ENOENT = 2;
+        public const int EINTR= 4;
+        public const int EAGAIN = 11;
+        public const int ENOMEM = 12;
+        public const int EACCES = 13;
+        public const int EINVAL = 22;
+        public const int ENFILE = 23;
+        public const int EMFILE = 24;
+        public const int ENAMETOOLONG = 36;
+        public const int EOVERFLOW = 75;
+        public const int ETIMEDOUT = 110;
+    }
+
+    private sealed partial class SemaphorePtr : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public SemaphorePtr(nint handle) : base(true)
+        {
+            SetHandle(handle);
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            return CloseSemaphore(handle) == 0;
+        }
+
+        [DllImport(ImportFileName)]
+        private static extern int CloseSemaphore(nint semaphore);
+    }
+
+    private SemaphorePtr? m_semaphore;
+    private SafeWaitHandle? m_safeWaitHandle;
+    private string? m_namespace;
+    private int m_maximumCount;
+
+    [AllowNull]
+    public SafeWaitHandle SafeWaitHandle
+    {
+        get => m_safeWaitHandle ?? new SafeWaitHandle(NamedSemaphore.InvalidHandle, false);
+        set => m_safeWaitHandle = value;
+    }
+
+    public void CreateSemaphoreCore(int initialCount, int maximumCount, string name, out bool createdNew)
+    {
+        if (initialCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(initialCount), "Non-negative number required.");
+
+        if (maximumCount < 1)
+            throw new ArgumentOutOfRangeException(nameof(maximumCount), "Positive number required.");
+
+        if (initialCount > maximumCount)
+            throw new ArgumentException("The initial count for the semaphore must be greater than or equal to zero and less than the maximum count.");
+
+        m_maximumCount = maximumCount;
+
+        int namespaceSeparatorIndex = name.IndexOf('\\');
+
+        if (namespaceSeparatorIndex > 0)
+        {
+            string namespaceName = name[..namespaceSeparatorIndex];
+
+            if (namespaceName != "Global" && namespaceName != "Local")
+                throw new ArgumentException("When using a namespace, the name of the semaphore must be prefixed with either \"Global\\\" or \"Local\\\".");
+
+            m_namespace = namespaceName;
+            name = name[(namespaceSeparatorIndex + 1)..];
+        }
+
+        if (name.Length > 250)
+            throw new ArgumentException("The name of the semaphore must be less than 251 characters.");
+
+        if (name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            throw new ArgumentException("The name of the semaphore contains invalid characters.");
+
+        int retval = CreateSemaphore(name, initialCount, out createdNew, out nint semaphoreHandle);
+
+        switch (retval)
+        {
+            case 0 when semaphoreHandle > 0:
+                m_semaphore = new SemaphorePtr(semaphoreHandle);
+                SafeWaitHandle = new SafeWaitHandle(semaphoreHandle, false);
+                return;
+            case ErrorNo.EACCES:
+                throw new UnauthorizedAccessException("The named semaphore exists, but the user does not have the security access required to use it.");
+            case ErrorNo.EINVAL:
+                throw new ArgumentOutOfRangeException(nameof(initialCount), "The value was greater than SEM_VALUE_MAX.");
+            case ErrorNo.EMFILE:
+                throw new IOException("The per-process limit on the number of open file descriptors has been reached.");
+            case ErrorNo.ENAMETOOLONG:
+                throw new PathTooLongException("The 'name' is too long. Length restrictions may depend on the operating system or configuration.");
+            case ErrorNo.ENFILE:
+                throw new IOException("The system limit on the total number of open files has been reached.");
+            case ErrorNo.ENOENT:
+                throw new WaitHandleCannotBeOpenedException("The 'name' is not well formed.");
+            case ErrorNo.ENOMEM:
+                throw new OutOfMemoryException("Insufficient memory to create the named semaphore.");
+            default:
+                if (semaphoreHandle == 0)
+                    throw new WaitHandleCannotBeOpenedException("The semaphore handle is invalid.");
+
+                throw new InvalidOperationException($"An unknown error occurred while creating the named semaphore. Error code: {retval}");
+        }
+    }
+
+    public void Dispose()
+    {
+        m_semaphore?.Dispose();
+        m_semaphore = null;
+    }
+
+    public static OpenExistingResult OpenExistingWorker(string name, out INamedSemaphore? semaphore)
+    {
+        semaphore = null;
+
+        int namespaceSeparatorIndex = name.IndexOf('\\');
+
+        if (namespaceSeparatorIndex > 0)
+        {
+            string namespaceName = name[..namespaceSeparatorIndex];
+
+            if (namespaceName != "Global" && namespaceName != "Local")
+                return OpenExistingResult.NameInvalid;
+
+            name = name[(namespaceSeparatorIndex + 1)..];
+        }
+
+        if (name.Length > 250)
+            return OpenExistingResult.NameInvalid;
+
+        if (name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            return OpenExistingResult.NameInvalid;
+
+        int retval = OpenExistingSemaphore(name, out nint semaphoreHandle);
+
+        switch (retval)
+        {
+            case 0 when semaphoreHandle > 0:
+                semaphore = new NamedSemaphoreUnix
+                {
+                    m_semaphore = new SemaphorePtr(semaphoreHandle),
+                    SafeWaitHandle = new SafeWaitHandle(semaphoreHandle, false)
+                };
+
+                return OpenExistingResult.Success;
+            case ErrorNo.ENAMETOOLONG:
+                return OpenExistingResult.PathTooLong;
+            default:
+                // Just return NameNotFound for all other errors
+                return OpenExistingResult.NameNotFound;
+        }
+    }
+
+    public int ReleaseCore(int releaseCount)
+    {
+        if (m_semaphore is null)
+            throw new ObjectDisposedException(nameof(NamedSemaphoreUnix));
+
+        if (releaseCount < 1)
+            throw new ArgumentOutOfRangeException(nameof(releaseCount), "Non-negative number required.");
+
+        int? previousCount = null;
+
+        for (int i = 0; i < releaseCount; i++)
+        {
+            int retval = GetSemaphoreCount(m_semaphore, out int count);
+            
+            if (retval == ErrorNo.EINVAL)
+                throw new InvalidOperationException("The named semaphore is invalid.");
+
+            if (retval != 0)
+                throw new InvalidOperationException($"An unknown error occurred while getting current count for the named semaphore. Error code: {retval}");
+
+            if (count >= m_maximumCount)
+                throw new SemaphoreFullException("The semaphore count is already at the maximum value.");
+
+            previousCount ??= count;
+
+            retval = ReleaseSemaphore(m_semaphore);
+
+            switch (retval)
+            {
+                case 0:
+                    continue;
+                case ErrorNo.EOVERFLOW:
+                    throw new SemaphoreFullException("The maximum count for the semaphore would be exceeded.");
+                case ErrorNo.EINVAL:
+                    throw new InvalidOperationException("The named semaphore is invalid.");
+                default:
+                    throw new InvalidOperationException($"An unknown error occurred while releasing the named semaphore. Error code: {retval}");
+            }
+        }
+
+        return previousCount ?? 0;
+    }
+
+    public void Close()
+    {
+        Dispose();
+    }
+
+    public bool WaitOne()
+    {
+        return WaitOne(Timeout.Infinite);
+    }
+
+    public bool WaitOne(TimeSpan timeout)
+    {
+        return WaitOne(ToTimeoutMilliseconds(timeout));
+    }
+
+    public bool WaitOne(int millisecondsTimeout)
+    {
+        if (m_semaphore is null)
+            return false;
+
+        int retval = WaitSemaphore(m_semaphore, millisecondsTimeout);
+
+        return retval switch
+        {
+            0 => true,
+            ErrorNo.EINTR => false,
+            ErrorNo.EAGAIN => false,
+            ErrorNo.ETIMEDOUT => false,
+            ErrorNo.EINVAL => throw new InvalidOperationException("The named semaphore is invalid."),
+            _ => throw new InvalidOperationException($"An unknown error occurred while releasing the named semaphore. Error code: {retval}")
+        };
+    }
+
+    public bool WaitOne(int millisecondsTimeout, bool exitContext)
+    {
+        return WaitOne(millisecondsTimeout);
+    }
+
+    public bool WaitOne(TimeSpan timeout, bool exitContext)
+    {
+        return WaitOne(timeout);
+    }
+
+    internal static int ToTimeoutMilliseconds(TimeSpan timeout)
+    {
+        long timeoutMilliseconds = (long)timeout.TotalMilliseconds;
+            
+        return timeoutMilliseconds switch
+        {
+            < -1 => throw new ArgumentOutOfRangeException(nameof(timeout), "Argument must be either non-negative and less than or equal to Int32.MaxValue or -1"),
+            > int.MaxValue => throw new ArgumentOutOfRangeException(nameof(timeout), "Argument must be less than or equal to Int32.MaxValue milliseconds."),
+            _ => (int)timeoutMilliseconds
+        };
+    }
+
+    [DllImport(ImportFileName)]
+    private static extern int CreateSemaphore(string name, int initialCount, out bool createdNew, out nint semaphoreHandle);
+
+    [DllImport(ImportFileName)]
+    private static extern int OpenExistingSemaphore(string name, out nint semaphoreHandle);
+
+    [DllImport(ImportFileName)]
+    private static extern int GetSemaphoreCount(SemaphorePtr semaphore, out int count);
+
+    [DllImport(ImportFileName)]
+    private static extern int ReleaseSemaphore(SemaphorePtr semaphore);
+
+    [DllImport(ImportFileName)]
+    private static extern int WaitSemaphore(SemaphorePtr semaphore, int timeout);
+
+    [DllImport(ImportFileName)]
+    private static extern int UnlinkSemaphore(string name);
+}

--- a/src/Gemstone.Threading/NamedSemaphoreWindows.cs
+++ b/src/Gemstone.Threading/NamedSemaphoreWindows.cs
@@ -20,9 +20,9 @@
 //       Generated original version of source code.
 //
 //******************************************************************************************************
+// ReSharper disable UnusedMember.Global
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.Versioning;
 using System.Threading;
@@ -34,10 +34,9 @@ namespace Gemstone.Threading
     {
         private Semaphore? m_semaphore;
 
-        [AllowNull]
-        public SafeWaitHandle SafeWaitHandle
+        public SafeWaitHandle? SafeWaitHandle
         {
-            get => m_semaphore?.SafeWaitHandle ?? new SafeWaitHandle(NamedSemaphore.InvalidHandle, false);
+            get => m_semaphore?.SafeWaitHandle;
             set
             {
                 if (m_semaphore is null)
@@ -57,7 +56,9 @@ namespace Gemstone.Threading
             m_semaphore?.Dispose();
         }
 
+    #if NET
         [SupportedOSPlatform("windows")]
+    #endif
         public static OpenExistingResult OpenExistingWorker(string name, out INamedSemaphore? semaphore)
         {
             semaphore = null;
@@ -125,6 +126,11 @@ namespace Gemstone.Threading
         public bool WaitOne(int millisecondsTimeout, bool exitContext)
         {
             return m_semaphore?.WaitOne(millisecondsTimeout, exitContext) ?? false;
+        }
+
+        public static void Unlink(string _)
+        {
+            // This function does nothing on Windows
         }
     }
 }

--- a/src/Gemstone.Threading/NamedSemaphoreWindows.cs
+++ b/src/Gemstone.Threading/NamedSemaphoreWindows.cs
@@ -1,0 +1,130 @@
+﻿//******************************************************************************************************
+//  NamedSemaphoreWindows.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  11/09/2023 - Ritchie Carroll
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Threading;
+using Microsoft.Win32.SafeHandles;
+
+namespace Gemstone.Threading
+{
+    internal class NamedSemaphoreWindows : INamedSemaphore
+    {
+        private Semaphore? m_semaphore;
+
+        [AllowNull]
+        public SafeWaitHandle SafeWaitHandle
+        {
+            get => m_semaphore?.SafeWaitHandle ?? new SafeWaitHandle(NamedSemaphore.InvalidHandle, false);
+            set
+            {
+                if (m_semaphore is null)
+                    return;
+
+                m_semaphore.SafeWaitHandle = value;
+            }
+        }
+
+        public void CreateSemaphoreCore(int initialCount, int maximumCount, string name, out bool createdNew)
+        {
+            m_semaphore = new Semaphore(initialCount, maximumCount, name, out createdNew);
+        }
+
+        public void Dispose()
+        {
+            m_semaphore?.Dispose();
+        }
+
+        [SupportedOSPlatform("windows")]
+        public static OpenExistingResult OpenExistingWorker(string name, out INamedSemaphore? semaphore)
+        {
+            semaphore = null;
+
+            try
+            {
+                semaphore = new NamedSemaphoreWindows { m_semaphore = Semaphore.OpenExisting(name) };
+
+                return OpenExistingResult.Success;
+            }
+            catch (ArgumentException)
+            {
+                return OpenExistingResult.NameInvalid;
+            }
+            catch (PathTooLongException)
+            {
+                return OpenExistingResult.PathTooLong;
+            }
+            catch (IOException)
+            {
+                return OpenExistingResult.NameInvalid;
+            }
+            catch (WaitHandleCannotBeOpenedException ex)
+            {
+                return string.IsNullOrWhiteSpace(ex.Message)
+                    ? OpenExistingResult.NameNotFound
+                    : OpenExistingResult.NameInvalid;
+            }
+            catch (Exception)
+            {
+                return OpenExistingResult.NameNotFound;
+            }
+        }
+
+        public int ReleaseCore(int releaseCount)
+        {
+            return m_semaphore?.Release(releaseCount) ?? 0;
+        }
+
+        public void Close()
+        {
+            m_semaphore?.Close();
+        }
+
+        public bool WaitOne()
+        {
+            return m_semaphore?.WaitOne() ?? false;
+        }
+
+        public bool WaitOne(TimeSpan timeout)
+        {
+            return m_semaphore?.WaitOne(timeout) ?? false;
+        }
+
+        public bool WaitOne(int millisecondsTimeout)
+        {
+            return m_semaphore?.WaitOne(millisecondsTimeout) ?? false;
+        }
+
+        public bool WaitOne(TimeSpan timeout, bool exitContext)
+        {
+            return m_semaphore?.WaitOne(timeout, exitContext) ?? false;
+        }
+
+        public bool WaitOne(int millisecondsTimeout, bool exitContext)
+        {
+            return m_semaphore?.WaitOne(millisecondsTimeout, exitContext) ?? false;
+        }
+    }
+}


### PR DESCRIPTION
FYI - Unix named semaphore depends on `Gemstone.POSIX.so`

`C` code to build this shared library can be found in the Gemstone `common` repo:
[`gemstone/common/src/Gemstone.POSIX/`](https://github.com/gemstone/common/tree/master/src/Gemstone.POSIX)