### PR TITLE
Updated NamedSemaphore to respect "Global\" namespace parameter on Linux

### DIFF
--- a/src/Gemstone.Threading/INamedSemaphore.cs
+++ b/src/Gemstone.Threading/INamedSemaphore.cs
@@ -55,9 +55,5 @@ namespace Gemstone.Threading
         bool WaitOne(TimeSpan timeout, bool exitContext);
 
         bool WaitOne(int millisecondsTimeout, bool exitContext);
-
-        static OpenExistingResult OpenExistingWorker(string name, out INamedSemaphore? semaphore) => throw new NotImplementedException();
-
-        static void Unlink(string name) => throw new NotImplementedException();
     }
 }

--- a/src/Gemstone.Threading/NamedSemaphore.cs
+++ b/src/Gemstone.Threading/NamedSemaphore.cs
@@ -68,6 +68,15 @@ public class NamedSemaphore : WaitHandle
     /// naming conventions, excluding slashes except for an optional namespace backslash. The name length is limited
     /// to 250 characters after any optional namespace.
     /// </param>
+    /// <remarks>
+    /// The <paramref name="name"/> may be prefixed with <c>Global\</c> or <c>Local\</c> to specify a namespace.
+    /// When the Global namespace is specified, the synchronization object may be shared with any processes on the system.
+    /// When the Local namespace is specified, which is also the default when no namespace is specified, the synchronization
+    /// object may be shared with processes in the same session. On Windows, a session is a login session, and services
+    /// typically run in a different non-interactive session. On Unix-like operating systems, each shell has its own session.
+    /// Session-local synchronization objects may be appropriate for synchronizing between processes with a parent/child
+    /// relationship where they all run in the same session.
+    /// </remarks>
     public NamedSemaphore(int initialCount, int maximumCount, string name) :
         this(initialCount, maximumCount, name, out _)
     {
@@ -90,6 +99,15 @@ public class NamedSemaphore : WaitHandle
     /// When method returns, contains <c>true</c> if the specified named system semaphore was created; otherwise,
     /// <c>false</c> if the semaphore already existed.
     /// </param>
+    /// <remarks>
+    /// The <paramref name="name"/> may be prefixed with <c>Global\</c> or <c>Local\</c> to specify a namespace.
+    /// When the Global namespace is specified, the synchronization object may be shared with any processes on the system.
+    /// When the Local namespace is specified, which is also the default when no namespace is specified, the synchronization
+    /// object may be shared with processes in the same session. On Windows, a session is a login session, and services
+    /// typically run in a different non-interactive session. On Unix-like operating systems, each shell has its own session.
+    /// Session-local synchronization objects may be appropriate for synchronizing between processes with a parent/child
+    /// relationship where they all run in the same session.
+    /// </remarks>
     public NamedSemaphore(int initialCount, int maximumCount, string name, out bool createdNew)
     {
         if (string.IsNullOrWhiteSpace(name))
@@ -260,6 +278,15 @@ public class NamedSemaphore : WaitHandle
     /// <returns>
     /// An object that represents the opened named semaphore.
     /// </returns>
+    /// <remarks>
+    /// The <paramref name="name"/> may be prefixed with <c>Global\</c> or <c>Local\</c> to specify a namespace.
+    /// When the Global namespace is specified, the synchronization object may be shared with any processes on the system.
+    /// When the Local namespace is specified, which is also the default when no namespace is specified, the synchronization
+    /// object may be shared with processes in the same session. On Windows, a session is a login session, and services
+    /// typically run in a different non-interactive session. On Unix-like operating systems, each shell has its own session.
+    /// Session-local synchronization objects may be appropriate for synchronizing between processes with a parent/child
+    /// relationship where they all run in the same session.
+    /// </remarks>
     public static NamedSemaphore OpenExisting(string name)
     {
         switch (OpenExistingWorker(name, out INamedSemaphore? result))
@@ -296,6 +323,15 @@ public class NamedSemaphore : WaitHandle
     /// <c>true</c> if the named semaphore was opened successfully; otherwise, <c>false</c>. In some cases,
     /// <c>false</c> may be returned for invalid names.
     /// </returns>
+    /// <remarks>
+    /// The <paramref name="name"/> may be prefixed with <c>Global\</c> or <c>Local\</c> to specify a namespace.
+    /// When the Global namespace is specified, the synchronization object may be shared with any processes on the system.
+    /// When the Local namespace is specified, which is also the default when no namespace is specified, the synchronization
+    /// object may be shared with processes in the same session. On Windows, a session is a login session, and services
+    /// typically run in a different non-interactive session. On Unix-like operating systems, each shell has its own session.
+    /// Session-local synchronization objects may be appropriate for synchronizing between processes with a parent/child
+    /// relationship where they all run in the same session.
+    /// </remarks>
     public static bool TryOpenExisting(string name, [NotNullWhen(true)] out NamedSemaphore? semaphore)
     {
         if (OpenExistingWorker(name, out INamedSemaphore? result) == OpenExistingResult.Success)

--- a/src/Gemstone.Threading/NamedSemaphoreUnix.cs
+++ b/src/Gemstone.Threading/NamedSemaphoreUnix.cs
@@ -100,7 +100,7 @@ internal partial class NamedSemaphoreUnix : INamedSemaphore
         if (!result)
             throw ex!;
 
-        int retVal = CreateSemaphore(semaphoreName!,namespaceName == "Global", initialCount, out createdNew, out nint semaphoreHandle);
+        int retVal = CreateSemaphore(semaphoreName!, namespaceName == "Global", initialCount, out createdNew, out nint semaphoreHandle);
 
         switch (retVal)
         {


### PR DESCRIPTION
This .NET code update is based on `Gemstone.POSIX` update to the `CreateSemaphore` function that now accepts a boolean `useGlobalScope` parameter:

https://github.com/gemstone/common/commit/d6dc0a36680a513fff9e4524670c80f5103610d0

When new parameter is `true`, read/write flags for semaphore have a wider scope with both current group and other users supported, in addition to current user.

POSIX systems use a local file to support the semaphore in the kernel - so these are simple file attributes that allow all users to access semaphore when `useGlobalScope` is `true`.

From the .NET code, this parameter is `true` when semaphore name is prefixed with `Global\`.

With respect to namespace operations, `NamedSemaphore` in this PR now matches behavior of .NET  `Mutex` which is already cross platform.

Note: PR also includes a minor optimization to the `NamedSemaphoreUnix.ReleaseCore` function.