### PR TITLE
Change `IsBackground` property of `LongSynchronizedOperation` to use `init`

### DIFF
--- a/src/Gemstone.Threading/InterprocessLock.cs
+++ b/src/Gemstone.Threading/InterprocessLock.cs
@@ -216,5 +216,4 @@ public static class InterprocessLock
 
         return namedSemaphore;
     }
-
 }

--- a/src/Gemstone.Threading/SynchronizedOperations/LongSynchronizedOperation.cs
+++ b/src/Gemstone.Threading/SynchronizedOperations/LongSynchronizedOperation.cs
@@ -99,7 +99,11 @@ public class LongSynchronizedOperation : SynchronizedOperationBase
     /// shutdown; consider a cancellable action for <see cref="LongSynchronizedOperation"/>
     /// instances that use a foreground thread.
     /// </remarks>
+#if NET
     public bool IsBackground { get; init; }
+#else
+    public bool IsBackground { get; set; }
+#endif
 
     #endregion
 

--- a/src/Gemstone.Threading/SynchronizedOperations/LongSynchronizedOperation.cs
+++ b/src/Gemstone.Threading/SynchronizedOperations/LongSynchronizedOperation.cs
@@ -31,7 +31,6 @@ namespace Gemstone.Threading.SynchronizedOperations;
 /// Represents a long-running synchronized operation that cannot run while it is already in progress.
 /// </summary>
 /// <remarks>
-/// <para>
 /// The action performed by the <see cref="LongSynchronizedOperation"/> is executed on
 /// its own dedicated thread when running the operation in the foreground asynchronously.
 /// When running on its own thread, the action is executed in a tight loop until all
@@ -40,11 +39,6 @@ namespace Gemstone.Threading.SynchronizedOperations;
 /// It is also recommended to prefer this type of operation if the speed of the operation
 /// is not critical or if completion of the operation is critical, such as when saving data
 /// to a file.
-/// </para>
-/// <para>
-/// If the <see cref="IsBackground"/> property is changed while the synchronized operation
-/// is running, behavior is undefined.
-/// </para>
 /// </remarks>
 public class LongSynchronizedOperation : SynchronizedOperationBase
 {
@@ -105,7 +99,7 @@ public class LongSynchronizedOperation : SynchronizedOperationBase
     /// shutdown; consider a cancellable action for <see cref="LongSynchronizedOperation"/>
     /// instances that use a foreground thread.
     /// </remarks>
-    public bool IsBackground { get; set; }
+    public bool IsBackground { get; init; }
 
     #endregion
 

--- a/src/Gemstone.Threading/SynchronizedOperations/LongSynchronizedOperation.cs
+++ b/src/Gemstone.Threading/SynchronizedOperations/LongSynchronizedOperation.cs
@@ -124,25 +124,25 @@ public class LongSynchronizedOperation : SynchronizedOperationBase
 
     private void ExecuteActionAsyncBackground()
     {
-        void taskAction()
+        void TaskAction()
         {
             if (ExecuteAction())
                 ExecuteActionAsync();
         }
 
-        Task.Factory.StartNew(taskAction, TaskCreationOptions.LongRunning);
+        Task.Factory.StartNew(TaskAction, TaskCreationOptions.LongRunning);
     }
 
     private void ExecuteActionAsyncForeground()
     {
-        void threadAction()
+        void ThreadAction()
         {
             while (ExecuteAction())
             {
             }
         }
 
-        new Thread(threadAction).Start();
+        new Thread(ThreadAction).Start();
     }
 
     #endregion

--- a/src/Gemstone.Threading/SynchronizedOperations/TaskSynchronizedOperation.cs
+++ b/src/Gemstone.Threading/SynchronizedOperations/TaskSynchronizedOperation.cs
@@ -68,15 +68,13 @@ public class TaskSynchronizedOperation : ISynchronizedOperation
     private class SynchronizedOperation : SynchronizedOperationBase
     {
         private Func<CancellationToken, Task> AsyncAction { get; }
+
         private Action<Exception>? ExceptionHandler { get; }
 
         public SynchronizedOperation(Func<CancellationToken, Task> asyncAction, Action<Exception>? exceptionHandler)
             : base(() => { })
         {
-            if (asyncAction is null)
-                throw new ArgumentNullException(nameof(asyncAction));
-
-            AsyncAction = asyncAction;
+            AsyncAction = asyncAction ?? throw new ArgumentNullException(nameof(asyncAction));
             ExceptionHandler = exceptionHandler;
         }
 
@@ -157,7 +155,7 @@ public class TaskSynchronizedOperation : ISynchronizedOperation
     public bool IsRunning => InternalSynchronizedOperation.IsRunning;
 
     /// <summary>
-    /// Gets a value to indiate whether the synchronized operation
+    /// Gets a value to indicate whether the synchronized operation
     /// has an additional operation that is pending execution after
     /// the currently running action has completed.
     /// </summary>


### PR DESCRIPTION
Using new C# property feature `init` to remove undefined behavior.